### PR TITLE
Pin GitHub Actions to latest release commit SHAs

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -6,6 +6,6 @@ jobs:
     name: Spellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.58.0
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: rojopolis/spellcheck-github-actions@0bf4b2f91efa259b52c202b09b0c3845c524ff36 # 0.58.0
       name: Spellcheck


### PR DESCRIPTION
This PR pins the GitHub Actions used in workflows to their specific commit SHAs with human-readable version comments.

## Changes:
- **actions/checkout**: Pinned from `master` to `v6.0.1` (commit: `8e8c483`)
- **rojopolis/spellcheck-github-actions**: Pinned from tag `0.58.0` to commit SHA (commit: `0bf4b2f`)

## Benefits:
- Improved security by pinning to specific commits
- Version comments added for Dependabot compatibility
- Dependabot can still update these pinned actions automatically

All actions are pinned to their latest available releases as of 2026-01-31.